### PR TITLE
Use body yaw in ik and fk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reachy_mini_rust_kinematics"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 
 [lib]
@@ -8,7 +8,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 env_logger = "0.11.8"
-nalgebra = "0.34.0"
+nalgebra = "0.32.3"
 pyo3 = "0.25.0"
 pyo3-log = "0.12.4"
 pyo3-stub-gen = "0.9.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ impl Kinematics {
             let yaw = body_yaw.unwrap();
             let rotation = nalgebra::Rotation3::from_axis_angle(
                 &nalgebra::Unit::new_normalize(Vector3::z()),
-                yaw,
+                -yaw,
             );
             let t_yaw = rotation.to_homogeneous();
             t_world_platform_target = t_yaw * t_world_platform;
@@ -363,7 +363,7 @@ impl Kinematics {
             // rotate
             let rotation = nalgebra::Rotation3::from_axis_angle(
                 &nalgebra::Unit::new_normalize(Vector3::z()),
-                -yaw,
+                yaw,
             );
             let t_yaw = rotation.to_homogeneous();
             t_world_platform = t_yaw * t_world_platform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,7 +435,7 @@ mod tests {
         let mut kinematics = initialize_kinematics();
         let t_world_platform =
             nalgebra::Matrix4::new_translation(&nalgebra::Vector3::new(0.0, 0.0, HEAD_Z_OFFSET));
-        let r = kinematics.inverse_kinematics(t_world_platform);
+        let r = kinematics.inverse_kinematics(t_world_platform, None);
         let expected_res = [
             0.5469084013213722,
             -0.6911929467384811,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use pyo3_stub_gen::{
 };
 use serde::Deserialize;
 
-
 const HEAD_Z_OFFSET: f64 = 0.177;
 
 #[gen_stub_pyclass]
@@ -54,7 +53,11 @@ impl ReachyMiniRustKinematics {
     }
 
     #[pyo3(signature = (t_world_platform, body_yaw=None))]
-    fn inverse_kinematics(&self, t_world_platform: [[f64; 4]; 4], body_yaw: Option<f64>) -> Vec<f64> {
+    fn inverse_kinematics(
+        &self,
+        t_world_platform: [[f64; 4]; 4],
+        body_yaw: Option<f64>,
+    ) -> Vec<f64> {
         let t_world_platform = Matrix4::new(
             t_world_platform[0][0],
             t_world_platform[0][1],
@@ -188,11 +191,14 @@ impl Kinematics {
     }
 
     #[allow(non_snake_case)]
-    pub fn inverse_kinematics(&mut self, t_world_platform: Matrix4<f64>, body_yaw: Option<f64>) -> Vec<f64> {
+    pub fn inverse_kinematics(
+        &mut self,
+        t_world_platform: Matrix4<f64>,
+        body_yaw: Option<f64>,
+    ) -> Vec<f64> {
         let mut joint_angles: Vec<f64> = vec![0.0; self.branches.len()];
         let rs = self.motor_arm_length;
         let rp = self.rod_length;
-
 
         let mut t_world_platform_target = t_world_platform;
         // if body yaw is specified, rotate the platform accordingly
@@ -205,7 +211,6 @@ impl Kinematics {
             let t_yaw = rotation.to_homogeneous();
             t_world_platform_target = t_yaw * t_world_platform;
         }
-
 
         for (k, branch) in self.branches.iter().enumerate() {
             let t_world_motor_inv = branch.t_world_motor.try_inverse().unwrap();
@@ -263,7 +268,11 @@ impl Kinematics {
     }
 
     #[allow(non_snake_case)]
-    pub fn forward_kinematics(&mut self, joint_angles: Vec<f64>, body_yaw: Option<f64>) -> Matrix4<f64> {
+    pub fn forward_kinematics(
+        &mut self,
+        joint_angles: Vec<f64>,
+        body_yaw: Option<f64>,
+    ) -> Matrix4<f64> {
         if self.branches.len() != 6 {
             panic!("Forward kinematics requires exactly 6 joint angles");
         }
@@ -446,11 +455,10 @@ mod tests {
             0.6911968541984359,
             -0.5469156644896231,
         ];
-        assert!(
-            r.iter()
-                .zip(expected_res.iter())
-                .all(|(a, b)| (a - b).abs() < 1e-6)
-        );
+        assert!(r
+            .iter()
+            .zip(expected_res.iter())
+            .all(|(a, b)| (a - b).abs() < 1e-6));
     }
 
     #[test]
@@ -491,12 +499,10 @@ mod tests {
             .flat_map(|row| row.iter())
             .copied()
             .collect();
-        assert!(
-            t_flat
-                .iter()
-                .zip(expected_flat.iter())
-                .all(|(a, b)| (a - b).abs() < 1e-6)
-        );
+        assert!(t_flat
+            .iter()
+            .zip(expected_flat.iter())
+            .all(|(a, b)| (a - b).abs() < 1e-6));
     }
 
     // test ik + fk consistency
@@ -513,12 +519,10 @@ mod tests {
         }
         let t_flat = t.as_slice().to_vec();
         let expected_res = t_world_platform.as_slice().to_vec();
-        assert!(
-            t_flat
-                .iter()
-                .zip(expected_res.iter())
-                .all(|(a, b)| (a - b).abs() < 1e-6)
-        );  
+        assert!(t_flat
+            .iter()
+            .zip(expected_res.iter())
+            .all(|(a, b)| (a - b).abs() < 1e-6));
     }
     // test ik + fk consistency with body yaw
     #[test]
@@ -535,11 +539,9 @@ mod tests {
         }
         let t_flat = t.as_slice().to_vec();
         let expected_res = t_world_platform.as_slice().to_vec();
-        assert!(
-            t_flat
-                .iter()
-                .zip(expected_res.iter())
-                .all(|(a, b)| (a - b).abs() < 1e-4)
-        );
+        assert!(t_flat
+            .iter()
+            .zip(expected_res.iter())
+            .all(|(a, b)| (a - b).abs() < 1e-4));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,10 +455,11 @@ mod tests {
             0.6911968541984359,
             -0.5469156644896231,
         ];
-        assert!(r
-            .iter()
-            .zip(expected_res.iter())
-            .all(|(a, b)| (a - b).abs() < 1e-6));
+        assert!(
+            r.iter()
+                .zip(expected_res.iter())
+                .all(|(a, b)| (a - b).abs() < 1e-6)
+        );
     }
 
     #[test]
@@ -499,10 +500,12 @@ mod tests {
             .flat_map(|row| row.iter())
             .copied()
             .collect();
-        assert!(t_flat
-            .iter()
-            .zip(expected_flat.iter())
-            .all(|(a, b)| (a - b).abs() < 1e-6));
+        assert!(
+            t_flat
+                .iter()
+                .zip(expected_flat.iter())
+                .all(|(a, b)| (a - b).abs() < 1e-6)
+        );
     }
 
     // test ik + fk consistency
@@ -519,10 +522,12 @@ mod tests {
         }
         let t_flat = t.as_slice().to_vec();
         let expected_res = t_world_platform.as_slice().to_vec();
-        assert!(t_flat
-            .iter()
-            .zip(expected_res.iter())
-            .all(|(a, b)| (a - b).abs() < 1e-6));
+        assert!(
+            t_flat
+                .iter()
+                .zip(expected_res.iter())
+                .all(|(a, b)| (a - b).abs() < 1e-6)
+        );
     }
     // test ik + fk consistency with body yaw
     #[test]
@@ -539,9 +544,11 @@ mod tests {
         }
         let t_flat = t.as_slice().to_vec();
         let expected_res = t_world_platform.as_slice().to_vec();
-        assert!(t_flat
-            .iter()
-            .zip(expected_res.iter())
-            .all(|(a, b)| (a - b).abs() < 1e-4));
+        assert!(
+            t_flat
+                .iter()
+                .zip(expected_res.iter())
+                .all(|(a, b)| (a - b).abs() < 1e-4)
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         nalgebra::Matrix4::new_translation(&nalgebra::Vector3::new(0.0, 0.0, head_z_offset));
 
     kinematics.reset_forward_kinematics(t_world_platform);
-    let r = kinematics.inverse_kinematics(t_world_platform);
+    let r = kinematics.inverse_kinematics(t_world_platform, None);
     println!("Inverse kinematics {:?}", r);
 
     // Test forward kinematics

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
     // Test forward kinematics
     kinematics.reset_forward_kinematics(t_world_platform);
     let joints = vec![0.3, 0.0, 0.0, 0.0, 0.0, 0.0];
-    let mut t = kinematics.forward_kinematics(joints);
+    let mut t = kinematics.forward_kinematics(joints, None);
 
     // remove head_z_offset
     t[(2, 3)] -= head_z_offset;

--- a/test.py
+++ b/test.py
@@ -21,14 +21,14 @@ for motor in motors:
 T_world_platform = np.eye(4)
 T_world_platform[:3, 3][2] = 0.177
 # T_world_platform = tf.translation_matrix((0, 0, 0.177))
-r = kin.inverse_kinematics(T_world_platform)
+r = kin.inverse_kinematics(T_world_platform, body_yaw=None)
 print("Inverse kinematics : ", r)
 
 kin.reset_forward_kinematics(T_world_platform)
 joints = np.array([0.3, 0.0, 0.0, 0.0, 0.0, 0.0])
 
 
-T = np.array(kin.forward_kinematics(joints))
+T = np.array(kin.forward_kinematics(joints, body_yaw=None))
 print(T)
 T[2, 3] -= head_z_offset
 print("Forward kinematics\n", T)

--- a/test.py
+++ b/test.py
@@ -21,14 +21,30 @@ for motor in motors:
 T_world_platform = np.eye(4)
 T_world_platform[:3, 3][2] = 0.177
 # T_world_platform = tf.translation_matrix((0, 0, 0.177))
-r = kin.inverse_kinematics(T_world_platform, body_yaw=None)
+r = kin.inverse_kinematics(T_world_platform)
 print("Inverse kinematics : ", r)
 
 kin.reset_forward_kinematics(T_world_platform)
 joints = np.array([0.3, 0.0, 0.0, 0.0, 0.0, 0.0])
 
 
-T = np.array(kin.forward_kinematics(joints, body_yaw=None))
+T = np.array(kin.forward_kinematics(joints))
+print(T)
+T[2, 3] -= head_z_offset
+print("Forward kinematics\n", T)
+
+print("Test with a body yaw of 0.5 rad")
+
+T_world_platform = np.eye(4)
+T_world_platform[:3, 3][2] = 0.177
+r = kin.inverse_kinematics(T_world_platform, 0.5)
+print("Inverse kinematics : ", r)
+
+kin.reset_forward_kinematics(T_world_platform)
+joints = np.array([0.3, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+
+T = np.array(kin.forward_kinematics(joints, 0.5))
 print(T)
 T[2, 3] -= head_z_offset
 print("Forward kinematics\n", T)


### PR DESCRIPTION
So this PR uses the body yaw with the ik and fk. 

Body yaw is an optional argument and can be left as None (both in python and rust). 

I've bumped the version in the Cargo.toml to 1.0.1 (maybe if should be more like 1.1.0 or something as it's breaking the API).